### PR TITLE
Add justfile for deployment tasks

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,32 @@
+set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
+
+image_name := "mc-website"
+
+install:
+    npm install
+
+build: install
+    npm run build
+
+deploy: build docker-build docker-run
+
+start:
+    npm start
+
+# Launch the development server
+# usage: just dev
+
+dev:
+    npm run dev
+
+# Build the Docker image
+# usage: just docker-build
+
+docker-build:
+    docker build -t {{image_name}} .
+
+# Run the Docker container
+# usage: just docker-run
+
+docker-run:
+    docker run -p 3000:3000 {{image_name}}

--- a/justfile
+++ b/justfile
@@ -3,21 +3,21 @@ set shell := ["bash", "-eu", "-o", "pipefail", "-c"]
 image_name := "mc-website"
 
 install:
-    npm install
+    pnpm install
 
 build: install
-    npm run build
+    pnpm build
 
 deploy: build docker-build docker-run
 
 start:
-    npm start
+    pnpm start
 
 # Launch the development server
 # usage: just dev
 
 dev:
-    npm run dev
+    pnpm dev
 
 # Build the Docker image
 # usage: just docker-build


### PR DESCRIPTION
## Summary
- add a Justfile with installation, build, docker and deploy tasks

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch `Inter` font)*

------
https://chatgpt.com/codex/tasks/task_e_686173a5f244832792faa632b53bdcd6